### PR TITLE
static site example - select-meta.lua - jaybe

### DIFF
--- a/example_static_site/Makefile
+++ b/example_static_site/Makefile
@@ -1,0 +1,45 @@
+# Definitions and Configurations Variables
+CONTENT_DIR=content
+BUILD_DIR=build
+SITE_DIR=site
+ASSETS_DIR=assets
+METADATA_DIR=metadata
+PANDOC_FROM=markdown+emoji
+# Find all markdown files
+MARKDOWN=$(shell find $(CONTENT_DIR) -iname "*.md")
+# Find all associated mardkown metadata files
+MARKDOWN_META=$(shell find $(METADATA_DIR) -iname "*.meta.yaml")
+# Form all 'meta.yaml' counterparts
+META=$(MARKDOWN:.md=.meta.yaml)
+# Form all 'html' counterparts
+HTML=$(META:.meta.yaml=.html)
+# For removing built meta files
+BUILT=$(META:.meta.yaml=.del.meta.yaml)
+#.PHONY = all $(META) $(HTML) $(BUILT) ASSETS
+all: $(META) $(HTML) $(BUILT) CP_ASSETS local
+# process markdown files through select-meta into $(BUILD_DIR)
+%.meta.yaml: %.md
+	$(shell mkdir -pv $(shell dirname $(BUILD_DIR)/$(@:$(CONTENT_DIR)/%=%)))
+	pandoc --data-dir . -ddefaults -s -f markdown -t markdown -L select-meta.lua $(METADATA_DIR)/$(@:$(CONTENT_DIR)/%=%) $< -o $(BUILD_DIR)/$(@:$(CONTENT_DIR)/%=%)
+# pandocify composed .meta.yaml md files to html into $(SITE_DIR)
+%.html: %.meta.yaml
+	$(shell mkdir -pv $(shell dirname $(SITE_DIR)/$(@:$(CONTENT_DIR)/%=%)))
+	pandoc --data-dir . -ddefaults -s --from $(PANDOC_FROM) --to html --toc $(BUILD_DIR)/$(<:$(CONTENT_DIR)/%=%) -o $(SITE_DIR)/$(@:$(CONTENT_DIR)/%=%)
+# delete metedata yaml build files
+%.del.meta.yaml: %.meta.yaml
+	rm -v $(BUILD_DIR)/$(<:$(CONTENT_DIR)/%=%)
+# copy assets to $(SITE_DIR)
+CP_ASSETS:
+	@echo Copying assets
+	@cp -apv $(ASSETS_DIR) $(SITE_DIR)
+# local web server via python3
+SERVER:
+	@echo Starting local web server:
+	@python3 -m http.server 8000 --bind 127.0.0.1 --directory $(SITE_DIR)
+OPEN:
+	@sleep 1
+	@echo Opening site:
+	@open http://127.0.0.1:8000
+
+local:
+	@make -j 2 SERVER OPEN

--- a/example_static_site/assets/css/normalize.css
+++ b/example_static_site/assets/css/normalize.css
@@ -1,0 +1,349 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers.
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Render the `main` element consistently in IE.
+ */
+
+main {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove the border on images inside links in IE 10.
+ */
+
+img {
+  border-style: none;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers.
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Correct the padding in Firefox.
+ */
+
+fieldset {
+  padding: 0.35em 0.75em 0.625em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10.
+ * 2. Remove the padding in IE 10.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Misc
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10+.
+ */
+
+template {
+  display: none;
+}
+
+/**
+ * Add the correct display in IE 10.
+ */
+
+[hidden] {
+  display: none;
+}

--- a/example_static_site/assets/css/style.css
+++ b/example_static_site/assets/css/style.css
@@ -1,0 +1,328 @@
+/*
+ * I add this to html files generated with pandoc.
+ */
+
+html {
+  font-size: 100%;
+  overflow-y: scroll;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
+body {
+  color: #444;
+  font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
+  font-size: 12px;
+  line-height: 1.7;
+  padding: 1em;
+  margin: auto;
+  max-width: 42em;
+  background: #fefefe;
+}
+
+a {
+  color: #0645ad;
+  text-decoration: none;
+}
+
+a:visited {
+  color: #0b0080;
+}
+
+a:hover {
+  color: #06e;
+}
+
+a:active {
+  color: #faa700;
+}
+
+a:focus {
+  outline: thin dotted;
+}
+
+*::-moz-selection {
+  background: rgba(255, 255, 0, 0.3);
+  color: #000;
+}
+
+*::selection {
+  background: rgba(255, 255, 0, 0.3);
+  color: #000;
+}
+
+a::-moz-selection {
+  background: rgba(255, 255, 0, 0.3);
+  color: #0645ad;
+}
+
+a::selection {
+  background: rgba(255, 255, 0, 0.3);
+  color: #0645ad;
+}
+
+p {
+  margin: 1em 0;
+}
+
+img {
+  max-width: 100%;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #111;
+  line-height: 125%;
+  margin-top: 2em;
+  font-weight: normal;
+}
+
+h4, h5, h6 {
+  font-weight: bold;
+}
+
+h1 {
+  font-size: 2.5em;
+}
+
+h2 {
+  font-size: 2em;
+}
+
+h3 {
+  font-size: 1.5em;
+}
+
+h4 {
+  font-size: 1.2em;
+}
+
+h5 {
+  font-size: 1em;
+}
+
+h6 {
+  font-size: 0.9em;
+}
+
+blockquote {
+  color: #666666;
+  margin: 0;
+  padding-left: 3em;
+  border-left: 0.5em #EEE solid;
+}
+
+hr {
+  display: block;
+  height: 2px;
+  border: 0;
+  border-top: 1px solid #aaa;
+  border-bottom: 1px solid #eee;
+  margin: 1em 0;
+  padding: 0;
+}
+
+pre, code, kbd, samp {
+  color: #000;
+  font-family: monospace, monospace;
+  _font-family: 'courier new', monospace;
+  font-size: 0.98em;
+}
+
+pre {
+  white-space: pre;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+b, strong {
+  font-weight: bold;
+}
+
+dfn {
+  font-style: italic;
+}
+
+ins {
+  background: #ff9;
+  color: #000;
+  text-decoration: none;
+}
+
+mark {
+  background: #ff0;
+  color: #000;
+  font-style: italic;
+  font-weight: bold;
+}
+
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+ul, ol {
+  margin: 1em 0;
+  padding: 0 0 0 2em;
+}
+
+li p:last-child {
+  margin-bottom: 0;
+}
+
+ul ul, ol ol {
+  margin: .3em 0;
+}
+
+dl {
+  margin-bottom: 1em;
+}
+
+dt {
+  font-weight: bold;
+  margin-bottom: .8em;
+}
+
+dd {
+  margin: 0 0 .8em 2em;
+}
+
+dd:last-child {
+  margin-bottom: 0;
+}
+
+img {
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+  vertical-align: middle;
+}
+
+figure {
+  display: block;
+  text-align: center;
+  margin: 1em 0;
+}
+
+figure img {
+  border: none;
+  margin: 0 auto;
+}
+
+figcaption {
+  font-size: 0.8em;
+  font-style: italic;
+  margin: 0 0 .8em;
+}
+
+table {
+  margin-bottom: 2em;
+  border-bottom: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+table th {
+  padding: .2em 1em;
+  background-color: #eee;
+  border-top: 1px solid #ddd;
+  border-left: 1px solid #ddd;
+}
+
+table td {
+  padding: .2em 1em;
+  border-top: 1px solid #ddd;
+  border-left: 1px solid #ddd;
+  vertical-align: top;
+}
+
+.author {
+  font-size: 1.2em;
+  text-align: left;
+}
+
+@media only screen and (min-width: 480px) {
+  body {
+    font-size: 14px;
+  }
+}
+@media only screen and (min-width: 768px) {
+  body {
+    font-size: 16px;
+  }
+}
+@media print {
+  * {
+    background: transparent !important;
+    color: black !important;
+    filter: none !important;
+    -ms-filter: none !important;
+  }
+
+  body {
+    font-size: 12pt;
+    max-width: 100%;
+  }
+
+  a, a:visited {
+    text-decoration: underline;
+  }
+
+  hr {
+    height: 1px;
+    border: 0;
+    border-bottom: 1px solid black;
+  }
+
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+
+  .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after {
+    content: "";
+  }
+
+  pre, blockquote {
+    border: 1px solid #999;
+    padding-right: 1em;
+    page-break-inside: avoid;
+  }
+
+  tr, img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  @page :left {
+    margin: 15mm 20mm 15mm 10mm;
+}
+
+  @page :right {
+    margin: 15mm 10mm 15mm 20mm;
+}
+
+  p, h2, h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2, h3 {
+    page-break-after: avoid;
+  }
+}

--- a/example_static_site/content/about/index.md
+++ b/example_static_site/content/about/index.md
@@ -1,0 +1,6 @@
+## All About It
+
+- This page has no `select-meta.lua` queries within its YAML.
+  - However, is still passing through `select-meta`.
+
+> It should just still work. :smile:

--- a/example_static_site/content/index.md
+++ b/example_static_site/content/index.md
@@ -1,0 +1,9 @@
+## Let the Test Speak for Itself[^1]
+
+> Any time is a good time for testing.
+
+[^1]: With modern technology, tests can speak for themselves!
+
+## Comments a la `select-meta`[^2]
+
+[^2]: <https://github.com/jgm/select-meta>

--- a/example_static_site/defaults/defaults.yaml
+++ b/example_static_site/defaults/defaults.yaml
@@ -1,0 +1,5 @@
+data-dir: .
+css:
+- /assets/css/normalize.css
+- /assets/css/style.css
+number-sections: true

--- a/example_static_site/filters/select-meta.lua
+++ b/example_static_site/filters/select-meta.lua
@@ -1,0 +1,165 @@
+-- lua filter for constructing metadata dynamically from YAML input
+-- sources, using database-like queries.
+-- Copyright (C) 2019 John MacFarlane, released under MIT license
+--
+-- Example of input:
+-- ---
+-- papers:
+-- - select: articles
+--   from: articles.yaml
+--   where: 'year > 2009'
+--   order: author, title asc
+--   limit: 5
+--   group: author
+-- ...
+
+local stringify = pandoc.utils.stringify
+
+local function read_metadata_file(fname)
+  local metafile = io.open(fname, 'r')
+  local content = metafile:read("*a")
+  metafile:close()
+  local metadata = pandoc.read(content, "markdown").meta
+  return metadata
+end
+
+local function parse_selector(val)
+  local where = ''
+  local order = ''
+  local groupby = ''
+  local limit
+  if val.where then
+    where = stringify(val.where)
+    end
+  if val.order then
+    order = stringify(val.order)
+    end
+  if val.group then
+    groupby = stringify(val.group)
+  end
+  if val.limit then
+    limit = tonumber(stringify(val.limit))
+  end
+  local field, comparison, value =
+              string.match(where, "%s*([%w_-]+)%s*([!=<>]+)%s(.*)")
+  local orderings = {}
+  for x in string.gmatch(order, "[%w_-]+") do
+    if x == 'asc' and #orderings > 0 then
+      orderings[#orderings][2] = true
+    elseif x == 'desc' and #orderings > 0 then
+      orderings[#orderings][2] = false
+    else
+      orderings[#orderings + 1] = {x, true}
+    end
+  end
+  return { source = stringify(val.from),
+           field  = stringify(val.select),
+           condition =
+             function (t)
+               if not field then
+                 return true
+               end
+               local target = t[field]
+               if not target then
+                 return false
+               end
+               local targetstr = stringify(target)
+               if comparison == '==' or comparison == '=' then
+                 return (targetstr == value)
+               elseif comparison == '>' then
+                 return (targetstr > value)
+               elseif comparison == '>=' then
+                 return (targetstr >= value)
+               elseif comparison == '<' then
+                 return (targetstr < value)
+               elseif comparison == '<=' then
+                 return (targetstr <= value)
+               elseif comparison == '!=' then
+                 return (targetstr ~= value)
+               else
+                 error("Unknown comparison operator " .. comparison)
+               end
+             end,
+
+           order =
+             function(x,y)
+               for _,ord in pairs(orderings) do
+                 local f, ascending = table.unpack(ord)
+                 local xs = x[f] and stringify(x[f])
+                 local ys = y[f] and stringify(y[f])
+                 if xs and (xs < ys) then
+                   return ascending
+                 elseif ys and (xs > ys) then
+                   return (not ascending)
+                 end
+               end
+               return false
+             end,
+
+           group =
+             function (t)
+               if not groupby then
+                 return t
+               else
+                 local ts = {}
+                 local index = {}
+                 for _,x in pairs(t) do
+                   local k = (x[groupby] and stringify(x[groupby])) or ''
+                   local i
+                   if index[k] then
+                     table.insert(ts[index[k]].items, x)
+                   else
+                     local new = pandoc.MetaMap({})
+                     new[groupby] = k
+                     new.items = pandoc.MetaList({x})
+                     table.insert(ts, new)
+                     index[k] = #ts
+                   end
+                 end
+                 return ts
+               end
+             end,
+
+             limit = limit
+         }
+end
+
+local function get_selected_metadata(val)
+  local selector = parse_selector(val)
+  local meta = read_metadata_file(selector.source)
+  for f in string.gmatch(selector.field, "[^%.]+") do
+    meta = meta[f]
+  end
+  local metalist = {}
+  local condition = selector.condition
+  for k,v in pairs(meta) do
+    if condition(v) then
+      table.insert(metalist, v)
+    end
+  end
+  if selector.order then
+     table.sort(metalist, selector.order)
+  end
+  if selector.limit then
+    local limit = selector.limit
+    for i,_ in pairs(metalist) do
+      if i > limit then
+        metalist[i] = nil
+      end
+    end
+  end
+  return pandoc.MetaList(selector.group(metalist))
+end
+
+return {
+  {
+    Meta = function(meta)
+      for k,val in pairs(meta) do
+        if val['select'] then
+          meta[k] = get_selected_metadata(val)
+        end
+      end
+      return meta
+    end,
+  }
+}

--- a/example_static_site/metadata/about/index.meta.yaml
+++ b/example_static_site/metadata/about/index.meta.yaml
@@ -1,0 +1,18 @@
+---
+title-prefix: The Site
+title: All About It
+subtitle: Subtitle of About all the Things
+author:
+- name: Mr. About Face
+  affiliation: University of About
+- name: Ms. Abdul
+  affiliation: Straight Up Now Baby
+date: 2020-01-30
+keywords:
+- test
+- pandoc
+- customization
+- awesomeness
+- about
+toc-title: About Page ToC
+---

--- a/example_static_site/metadata/index.comments.yaml
+++ b/example_static_site/metadata/index.comments.yaml
@@ -1,0 +1,15 @@
+---
+comments:
+- comment: This is just lovely.
+  date: 2020-01-27
+  commentor: jaybe
+- comment: How can you have any pudding if you don't eat your meat?
+  date: 2020-01-01
+  commentor: Floyd
+- comment: This is an older comment.
+  date: 2019-12-12
+  commentor: Sid
+- comment: All your bases are belong to us
+  date: 2019-12-31
+  commentor: Anyong
+---

--- a/example_static_site/metadata/index.meta.yaml
+++ b/example_static_site/metadata/index.meta.yaml
@@ -1,0 +1,22 @@
+---
+title-prefix: The Site
+title: A Fitting Title
+subtitle: A Non-conforming Subtitle
+author:
+- name: Author One
+  affiliation: University of Internets
+- name: Author Two
+  affiliation: Backstreet Education
+date: 2020-01-26
+keywords:
+- test
+- pandoc
+- customization
+- awesomeness
+comments:
+  select: comments
+  from: 'metadata/index.comments.yaml'
+  order: date desc
+  limit: 3
+toc-title: Home - Table of Contents
+---

--- a/example_static_site/templates/comments.markdown
+++ b/example_static_site/templates/comments.markdown
@@ -1,0 +1,5 @@
+${ for(comments) }
+${ for(it.items) }
+> <p class=comments>On ${ it.date }, ${ it.commentor } commented, "${ it.comment }"</p>
+${ endfor }
+${ endfor }

--- a/example_static_site/templates/default.html5
+++ b/example_static_site/templates/default.html5
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$lang$" xml:lang="$lang$"$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+$for(author-meta)$
+  <meta name="author" content="$author-meta$" />
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$" />
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style>
+    $styles.html()$
+  </style>
+$for(css)$
+  <link rel="stylesheet" href="$css$" />
+$endfor$
+$if(math)$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<header id="title-block-header">
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<p class="subtitle">$subtitle$</p>
+$endif$
+
+$for(author)$
+$if(author.name)$
+<p class="author">$author.name$$if(author.affiliation)$ ($author.affiliation$)$endif$</p>
+$else$
+$author$
+$endif$
+$endfor$
+
+$if(date)$
+<p class="date">$date$</p>
+$endif$
+</header>
+$endif$
+$if(toc)$
+<nav id="$idprefix$TOC" role="doc-toc">
+$if(toc-title)$
+<h2 id="$idprefix$toc-title">$toc-title$</h2>
+$endif$
+$table-of-contents$
+</nav>
+$endif$
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</body>
+</html>

--- a/example_static_site/templates/default.markdown
+++ b/example_static_site/templates/default.markdown
@@ -1,0 +1,22 @@
+$if(titleblock)$
+$titleblock$
+
+$endif$
+$for(header-includes)$
+$header-includes$
+
+$endfor$
+$for(include-before)$
+$include-before$
+
+$endfor$
+$if(toc)$
+$table-of-contents$
+
+$endif$
+$body$
+${ comments() }
+$for(include-after)$
+
+$include-after$
+$endfor$


### PR DESCRIPTION
Example of static site generation for HTML site. Goal is separation of `content`, from `meta`, from `layout`, and with the ability to leverage `select-meta.lua` to query additional metadata for inclusion within .md content files.

- content files are markdown only, without any yaml metadata within; pure markdown content files.
  - e.g. `content/index.md`
- metadata for `index.md` is in `metadata/index.meta.yaml`
- sample comments are queried from `metadata/index.comments.yaml`
  - queried from `content/index.md` via `select-meta.lua`

There is also an `about` page/content example represented; `content/about/index.md`.

Use `make all` from within the example site directory.

The Makefile will find .md content files, build them- including "dynamic queried metadata" with select-meta.lua, then output into the `site/` folder.

The Makefile will also open a local web server with `python3` and leverage the `open` command on MacOS to open the site.  This was designed, tested, and works with MacOS.